### PR TITLE
TFLu CMake build system prototype

### DIFF
--- a/tensorflow/lite/micro/CMakeLists.txt
+++ b/tensorflow/lite/micro/CMakeLists.txt
@@ -1,0 +1,171 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.15.6)
+
+# Set default compile options if no toolchain file has been provided
+if (NOT CMAKE_TOOLCHAIN_FILE)
+    set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain/default.cmake)
+endif()
+
+project(tensorflow-microlite VERSION 0.0.1)
+
+include(CTest)
+include(cmake/helpers.cmake)
+
+#############################################################################
+# Helper functions
+#############################################################################
+
+set(TENSORFLOW_TEST_COMMAND "" CACHE STRING "Command used to run unit tests")
+
+# Build a test from source
+function(tensorflow_add_test target)
+    if(NOT BUILD_TESTING)
+        return()
+    endif()
+
+    cmake_parse_arguments(ARGS "" "" "SOURCES;LIBRARIES" ${ARGN})
+
+    add_executable(${target})
+    target_sources(${target} PRIVATE ${ARGS_SOURCES})
+    target_link_libraries(${target} PRIVATE tensorflow-tests ${ARGS_LIBRARIES})
+
+    add_test(NAME tensorflow_${target}
+             COMMAND ${TENSORFLOW_TEST_COMMAND} $<TARGET_FILE:${target}>)
+endfunction()
+
+function(tensorflow_add_tests)
+    foreach(source IN LISTS ARGN)
+        get_filename_component(target ${source} NAME_WLE)
+        tensorflow_add_test(${target} SOURCES ${source})
+    endforeach()
+endfunction()
+
+#############################################################################
+# Add targets
+#############################################################################
+
+# Tensorflow microlite library
+add_library(tensorflow-microlite STATIC)
+
+# All unit tests link against this interface library. This library can be
+# used to add compile and link options that affect all unit test binaries
+add_library(tensorflow-tests INTERFACE)
+
+#############################################################################
+# Download thirdparty
+#############################################################################
+
+# Flatbuffers
+download_third_party(tensorflow-flatbuffers
+    URL "http://mirror.tensorflow.org/github.com/google/flatbuffers/archive/dca12522a9f9e37f126ab925fd385c807ab4f84e.tar.gz"
+    URL_MD5 dfa0ac3073b78ddacdcacf8ca189be91)
+
+target_include_directories(tensorflow-microlite PUBLIC
+    ${tensorflow-flatbuffers_SOURCE_DIR}/include)
+
+# Gemlowp
+download_third_party(tensorflow-gemlowp
+    URL "https://github.com/google/gemmlowp/archive/719139ce755a0f31cbf1c37f7f98adcc7fc9f425.zip"
+    URL_MD5 7e8191b24853d75de2af87622ad293ba)
+
+target_include_directories(tensorflow-microlite PUBLIC
+    ${tensorflow-gemlowp_SOURCE_DIR})
+
+# Ruy
+download_third_party(tensorflow-ruy
+    URL "https://github.com/google/ruy/archive/5bb02fbf90824c2eb6cd7418f766c593106a332b.zip"
+    URL_MD5 c720b1743360259ac45809a321f8f26c)
+
+target_include_directories(tensorflow-microlite PUBLIC
+    ${tensorflow-ruy_SOURCE_DIR})
+
+# CMSIS
+download_third_party(tensorflow-cmsis
+    URL "http://github.com/ARM-software/CMSIS_5/archive/01f5b32badf7b78c85a24a7149b56400fa6a2999.zip"
+    URL_MD5 823916c6f1749c65fd0bfdeec20b30ed)
+
+set(TENSORFLOW_CMSIS_PATH "${tensorflow-cmsis_SOURCE_DIR}" CACHE PATH "Path to CMSIS")
+
+# Ethos-U
+download_third_party(tensorflow-ethos-u
+    URL "https://git.mlplatform.org/ml/ethos-u/ethos-u-core-driver.git/snapshot/ethos-u-core-driver-2b201c340788ac582cec160b7217c2b5405b04f9.tar.gz"
+    URL_MD5 0c148b90a1ee01de398892eb3a63e717)
+
+set(TENSORFLOW_ETHOS_U_PATH "${tensorflow-ethos-u_SOURCE_DIR}" CACHE PATH "Path to Ethos-U")
+
+#############################################################################
+# Tensorflow
+#############################################################################
+
+# Microlite lib
+target_include_directories(tensorflow-microlite PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+target_compile_definitions(tensorflow-microlite PUBLIC
+    TF_LITE_STATIC_MEMORY
+    TF_LITE_DISABLE_X86_NEON)
+
+target_sources(tensorflow-microlite PRIVATE
+    all_ops_resolver.cc
+    debug_log.cc
+    memory_helpers.cc
+    micro_allocator.cc
+    micro_error_reporter.cc
+    micro_interpreter.cc
+    micro_profiler.cc
+    micro_string.cc
+    micro_time.cc
+    micro_utils.cc
+    recording_micro_allocator.cc
+    recording_simple_memory_allocator.cc
+    simple_memory_allocator.cc
+    test_helpers.cc)
+
+target_sources(tensorflow-microlite PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../c/common.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core/api/error_reporter.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core/api/flatbuffer_conversions.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core/api/op_resolver.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../core/api/tensor_utils.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../kernels/internal/quantization_util.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../kernels/kernel_util.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../schema/schema_utils.cc)
+
+target_link_libraries(tensorflow-tests INTERFACE
+    tensorflow-microlite)
+
+tensorflow_add_tests(
+    memory_arena_threshold_test.cc
+    memory_helpers_test.cc
+    micro_allocator_test.cc
+    micro_error_reporter_test.cc
+    micro_interpreter_test.cc
+    micro_mutable_op_resolver_test.cc
+    micro_string_test.cc
+    micro_time_test.cc
+    micro_utils_test.cc
+    recording_micro_allocator_test.cc
+    recording_simple_memory_allocator_test.cc
+    simple_memory_allocator_test.cc
+    testing_helpers_test.cc)
+
+add_subdirectory(kernels)
+add_subdirectory(cortex_m_generic)
+add_subdirectory(memory_planner)
+add_subdirectory(benchmarks)
+add_subdirectory(testing)
+add_subdirectory(examples)

--- a/tensorflow/lite/micro/README_CMAKE.md
+++ b/tensorflow/lite/micro/README_CMAKE.md
@@ -1,0 +1,199 @@
+# CMake
+
+CMake is a cross-platform tool that is used to generate build files for a range
+of different build tools. The process can be divided into.
+
+1. Configuration with CMake.
+2. Building with the selected generator.
+3. Running tests with `ctest`.
+4. Packaging.
+
+## Configuration
+
+To keep the similarities to the existing makefile build system, all examples
+below assume we are calling `cmake` from the Tensorflow root folder.
+
+### Default configuration
+
+CMake is designed to generate build files *out of tree*.
+
+```
+$ cmake -B build tensorflow/lite/micro
+```
+
+Configuration file are found in the `build` folder.
+
+### Enabling options
+
+Build options can be listed with `cmake -LH` and are set on the command line prefixed by `-D`.
+
+```
+$ cmake -B build tensorflow/lite/micro -DTENSORFLOW_CMSIS_NN=ON
+```
+
+### Cross compiling
+
+Cross compiling is preferably setup in an external toolchain file. There are
+toolchain files provided for reference under
+`tensorflow/lite/micro/cmake/toolchain`, but there is nothing preventing a user
+from defining a custom toolchain file.
+
+```
+$ cmake -B build tensorflow/lite/micro -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/arm-none-eabi-gcc.cmake -DTENSORFLOW_CPU=cortex-m4
+```
+
+## Building
+
+This section assumes we have changed to the `build` directory and that `make`
+was used as generator in the configuration step.
+
+```
+$ make
+```
+
+### Building individual targets
+
+The build targets CMake has created can be listed with `make help` and can be build separatelly.
+
+```
+$ make tensorflow-microlite
+```
+
+## Testing
+
+Running tests is done by `ctest`.
+
+```
+$ ctest
+```
+
+The available tests can be listed with `ctest -N` and run individually with `ctest -R <regular expression>`.
+
+```
+$ ctest -R person-detection
+```
+
+### Running cross compiled tests
+
+Running cross compiled tests will required either a physical target or an emulator.
+
+# Examples
+
+This section lists a few example how to build with the existing build system,
+comparing that with the equivalent CMake commands.
+
+All examles assume we begin at the root of the Tensorflow repo.
+
+## Building and testing conv_test only
+
+Building and testing the *conv_test* only looks like this with the existing
+build system.
+
+```
+$ make -f tensorflow/lite/micro/tools/make/Makefile test_kernel_conv_test
+```
+
+`cmake` is run without any special arguments. However `make` and `ctest` are
+passed extra arguments to limit the build process and the test scope.
+
+1. Change to Tensorflow root folder.
+2. Remove build folder.
+   ```
+   $ rm -rf build
+   ```
+3. Configure
+   ```
+   $ cmake -B build tensorflow/lite/micro
+   ```
+4. Build (native)
+   ```
+   $ cd build
+   $ make conv_test
+   ```
+5. Test
+   ```
+   $ ctest -V -R tensorflow_conv_test
+   ```
+
+## Cross compiling microlite
+
+In the exampe below the microlite library is cross compiled for Arm Cortex-M4
+with CMSIS-NN enabled. Equivalent to this command in the original make based
+build system.
+
+```
+$ make -f tensorflow/lite/micro/tools/make/Makefile TAGS=cmsis-nn TARGET=cortex_m_generic TARGET_ARCH=cortex-m4+fp microlite
+```
+
+Cross compiling in CMake requires a toolchain file. For this particular example
+​we are using a toolchain file that has been provided as an example. This
+toolchain takes `TENSORFLOW_CPU` as input allowing the user to select which CPU
+to compile for.
+
+1. Change to Tensorflow root folder.
+2. Remove build folder.
+   ```
+   $ rm -rf build
+   ```
+3. Configure
+   ```
+   $ cmake -B build tensorflow/lite/micro -DCMAKE_TOOLCHAIN_FILE=$PWD/tensorflow/lite/micro/cmake/toolchain/armclang.cmake -DTENSORFLOW_CPU=cortex-m4 -DTENSORFLOW_CMSIS_NN=ON
+   ```
+4. Build
+   ```
+   $ cd build
+   $ make tensorflow-microlite
+   ```
+
+## Building person detection binary for Sparkfun
+
+Building the SparkFun Edge target is split into a configuration step with
+`cmake` and a build step with `make`. This is equivalent to the following
+command in the existing make build system:
+
+```
+$ make -f tensorflow/lite/micro/tools/make/Makefile TARGET=sparkfun_edge person_detection_int8_bin
+```
+
+1. Change to Tensorflow root folder.
+2. Remove build folder.
+   ```
+   $ rm -rf build
+   ```
+3. Configure.
+   ```
+   $ cmake -B build tensorflow/lite/micro/targets/sparkfun_edge
+   ```
+4. Build person detection binary
+   ```
+   $ cd build
+   $ make person-detection
+   ```
+
+Find the binary here `build/tensorflow-microlite/examples/person_detection/`.
+
+## Verbose build and testing
+
+CMake and CTest will by default limit the information printed to the console.
+Verbose builds and extra debug information can be enabled by passing extra
+arguments to `make` and `ctest`.
+
+```
+$ make VERBOSE=1
+$ ctest -V
+```
+
+## Clean build
+
+The build directory can be cleaned without having to rerun CMake.
+
+```
+$ make clean
+```
+
+CMake places all downloads and build artifacts out of tree. Removing the build
+directory is the safest way to produce a clean build.
+
+```
+$ rm -rf build
+```

--- a/tensorflow/lite/micro/benchmarks/CMakeLists.txt
+++ b/tensorflow/lite/micro/benchmarks/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+target_sources(tensorflow-microlite PRIVATE
+    keyword_scrambled_model_data.cc)

--- a/tensorflow/lite/micro/cmake/helpers.cmake
+++ b/tensorflow/lite/micro/cmake/helpers.cmake
@@ -1,0 +1,39 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(FetchContent)
+
+# Download third party
+macro(download_third_party target)
+    cmake_parse_arguments(DOWNLOAD "" "URL;URL_MD5" "PATCHES" ${ARGN})
+    message("Downloading ${DOWNLOAD_URL}")
+
+    FetchContent_Declare(${target}
+                         URL ${DOWNLOAD_URL}
+                         URL_MD5 ${DOWNLOAD_MD5}
+                         ${PATCH_COMMAND})
+
+    FetchContent_GetProperties(${target})
+    if (NOT ${target}_POPULATED)
+        FetchContent_Populate(${target})
+    endif()
+
+    foreach(patch ${DOWNLOAD_PATCHES})
+        execute_process(
+            COMMAND patch -p1 -d ${${target}_SOURCE_DIR} -i ${CMAKE_CURRENT_SOURCE_DIR}/${patch}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            OUTPUT_VARIABLE null)
+    endforeach()
+endmacro()

--- a/tensorflow/lite/micro/cmake/toolchain/arm-none-eabi-gcc.cmake
+++ b/tensorflow/lite/micro/cmake/toolchain/arm-none-eabi-gcc.cmake
@@ -1,0 +1,61 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(TENSORFLOW_CPU "cortex-m33+nodsp" CACHE STRING "Select Cortex-M processor")
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_C_COMPILER "arm-none-eabi-gcc")
+set(CMAKE_CXX_COMPILER "arm-none-eabi-g++")
+
+string(REPLACE "+" ";" __CPU_FEATURES ${TENSORFLOW_CPU})
+list(POP_FRONT __CPU_FEATURES CMAKE_SYSTEM_PROCESSOR)
+string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} CMAKE_SYSTEM_PROCESSOR)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
+
+# CPU target
+add_compile_options(-mcpu=${TENSORFLOW_CPU})
+add_link_options(-mcpu=${TENSORFLOW_CPU} --specs=nosys.specs)
+
+# Complation warnings
+add_compile_options(
+#    -Werror
+    -Wsign-compare
+    -Wdouble-promotion
+    -Wshadow
+    -Wunused-variable
+    -Wmissing-field-initializers
+    -Wunused-function
+    -Wswitch
+    -Wvla
+    -Wall
+    -Wextra
+    -Wstrict-aliasing
+    -Wno-unused-parameter)
+
+# Configure compiler features
+add_compile_options(
+    -fno-unwind-tables
+    -ffunction-sections
+    -fdata-sections
+    -fmessage-length=0
+    "$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti;-fno-exceptions;-fno-threadsafe-statics>")

--- a/tensorflow/lite/micro/cmake/toolchain/armclang.cmake
+++ b/tensorflow/lite/micro/cmake/toolchain/armclang.cmake
@@ -1,0 +1,60 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(TENSORFLOW_CPU "cortex-m33+nodsp" CACHE STRING "Select Cortex-M processor")
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_C_COMPILER "armclang")
+set(CMAKE_CXX_COMPILER "armclang")
+
+string(REPLACE "+" ";" __CPU_FEATURES ${TENSORFLOW_CPU})
+list(POP_FRONT __CPU_FEATURES CMAKE_SYSTEM_PROCESSOR)
+string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} CMAKE_SYSTEM_PROCESSOR)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
+
+# CPU target
+add_compile_options(-mcpu=${TENSORFLOW_CPU} -mthumb)
+add_link_options(--cpu=${CMAKE_SYSTEM_PROCESSOR})
+add_link_options(--lto --info common,debug,sizes,totals,veneers,unused --symbols --diag_suppress=L6439W)
+
+# Complation warnings
+add_compile_options(
+#    -Werror
+    -Wsign-compare
+    -Wdouble-promotion
+    -Wshadow
+    -Wunused-variable
+    -Wmissing-field-initializers
+    -Wunused-function
+    -Wswitch
+    -Wvla
+    -Wall
+    -Wextra
+    -Wstrict-aliasing
+    -Wno-unused-parameter)
+
+# Floating point
+add_compile_options(-mfloat-abi=hard)
+
+# Configure compiler features
+add_compile_options(
+    -fno-unwind-tables
+    -ffunction-sections
+    -fdata-sections
+    -fmessage-length=0
+    "$<$<CONFIG:DEBUG>:-gdwarf-3>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti;-fno-exceptions;-fno-threadsafe-statics>")

--- a/tensorflow/lite/micro/cmake/toolchain/default.cmake
+++ b/tensorflow/lite/micro/cmake/toolchain/default.cmake
@@ -1,0 +1,39 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Complation warnings
+add_compile_options(
+#    -Werror
+    -Wsign-compare
+    -Wdouble-promotion
+    -Wshadow
+    -Wunused-variable
+    -Wmissing-field-initializers
+    -Wunused-function
+    -Wswitch
+    -Wvla
+    -Wall
+    -Wextra
+    -Wstrict-aliasing
+    -Wno-unused-parameter)
+
+# Configure compiler features
+add_compile_options(
+    -fno-unwind-tables
+    -ffunction-sections
+    -fdata-sections
+    -fmessage-length=0
+    "$<$<CONFIG:DEBUG>:-gdwarf-3>"
+    "$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti;-fno-exceptions;-fno-threadsafe-statics>")

--- a/tensorflow/lite/micro/cortex_m_generic/CMakeLists.txt
+++ b/tensorflow/lite/micro/cortex_m_generic/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} CMAKE_SYSTEM_PROCESSOR_LOWER)
+
+if(${CMAKE_SYSTEM_PROCESSOR_LOWER} MATCHES "cortex-m.*")
+    target_sources(tensorflow-microlite PRIVATE
+        debug_log.cc)
+endif()

--- a/tensorflow/lite/micro/examples/CMakeLists.txt
+++ b/tensorflow/lite/micro/examples/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(person_detection)

--- a/tensorflow/lite/micro/examples/person_detection/CMakeLists.txt
+++ b/tensorflow/lite/micro/examples/person_detection/CMakeLists.txt
@@ -1,0 +1,70 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Flatbuffers
+download_third_party(tensorflow-person-detection-model
+                     URL "https://storage.googleapis.com/download.tensorflow.org/data/tf_lite_micro_person_data_int8_grayscale_2020_12_1.zip"
+                     URL_MD5 e765cc76889db8640cfe876a37e4ec00)
+
+add_library(person-detection-model INTERFACE)
+
+# Person detection model
+target_sources(person-detection-model INTERFACE
+    model_settings.cc
+    ${tensorflow-person-detection-model_SOURCE_DIR}/person_detect_model_data.cc)
+
+# Person detection test
+tensorflow_add_test(person-detection-test
+                    SOURCES
+                        person_detection_test.cc
+                        ${tensorflow-person-detection-model_SOURCE_DIR}/no_person_image_data.cc
+                        ${tensorflow-person-detection-model_SOURCE_DIR}/person_image_data.cc
+                    LIBRARIES person-detection-model)
+
+# Image provider test
+tensorflow_add_test(person-detection-image-provider
+                    SOURCES
+                        image_provider_test.cc
+                        image_provider.cc
+                    LIBRARIES person-detection-model)
+
+# Detection responder test
+tensorflow_add_test(person-detection-responder
+                    SOURCES
+                        detection_responder_test.cc
+                        detection_responder.cc
+                    LIBRARIES person-detection-model)
+
+# Person detection
+tensorflow_add_test(person-detection
+    SOURCES
+        main.cc
+        main_functions.cc
+    LIBRARIES person-detection-model)
+
+if (TENSORFLOW_TARGET STREQUAL "sparkfun_edge")
+    target_sources(person-detection PRIVATE
+        himax_driver/HM01B0.c
+        himax_driver/HM01B0_debug.c
+        himax_driver/HM01B0_optimized.c
+        sparkfun_edge/detection_responder.cc
+        sparkfun_edge/image_provider.cc)
+else()
+    target_sources(person-detection PRIVATE
+        detection_responder.cc
+        image_provider.cc)
+    set_tests_properties(tensorflow_person-detection PROPERTIES
+        DISABLED TRUE)
+endif()

--- a/tensorflow/lite/micro/kernels/CMakeLists.txt
+++ b/tensorflow/lite/micro/kernels/CMakeLists.txt
@@ -1,0 +1,121 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(cmsis_nn)
+add_subdirectory(ethos_u)
+
+target_sources(tensorflow-microlite PRIVATE
+    activations.cc
+    add.cc
+    arg_min_max.cc
+    batch_to_space_nd.cc
+    cast.cc
+    ceil.cc
+    circular_buffer.cc
+    comparisons.cc
+    concatenation.cc
+    conv.cc
+    conv_test_common.cc
+    depthwise_conv.cc
+    dequantize.cc
+    detection_postprocess.cc
+    elementwise.cc
+    ethosu.cc
+    exp.cc
+    flexbuffers_generated_data.cc
+    floor.cc
+    fully_connected.cc
+    fully_connected_common.cc
+    hard_swish.cc
+    kernel_runner.cc
+    kernel_util.cc
+    l2norm.cc
+    logical.cc
+    logistic.cc
+    maximum_minimum.cc
+    mul.cc
+    neg.cc
+    pack.cc
+    pad.cc
+    pooling.cc
+    prelu.cc
+    quantize.cc
+    quantize_common.cc
+    reduce.cc
+    reshape.cc
+    resize_nearest_neighbor.cc
+    round.cc
+    shape.cc
+    softmax.cc
+    softmax_common.cc
+    space_to_batch_nd.cc
+    split.cc
+    split_v.cc
+    strided_slice.cc
+    sub.cc
+    svdf.cc
+    svdf_common.cc
+    tanh.cc
+    transpose_conv.cc
+    unpack.cc
+    zeros_like.cc)
+
+tensorflow_add_tests(
+    activations_test.cc
+    add_test.cc
+    arg_min_max_test.cc
+    batch_to_space_nd_test.cc
+    cast_test.cc
+    ceil_test.cc
+    circular_buffer_test.cc
+    comparisons_test.cc
+    concatenation_test.cc
+    conv_test.cc
+    depthwise_conv_test.cc
+    dequantize_test.cc
+    detection_postprocess_test.cc
+    elementwise_test.cc
+    exp_test.cc
+    floor_test.cc
+    fully_connected_test.cc
+    hard_swish_test.cc
+    l2norm_test.cc
+    logical_test.cc
+    logistic_test.cc
+    maximum_minimum_test.cc
+    mul_test.cc
+    neg_test.cc
+    pack_test.cc
+    pad_test.cc
+    pooling_test.cc
+    prelu_test.cc
+    quantization_util_test.cc
+    quantize_test.cc
+    reduce_test.cc
+    reshape_test.cc
+    resize_nearest_neighbor_test.cc
+    round_test.cc
+    shape_test.cc
+    softmax_test.cc
+    space_to_batch_nd_test.cc
+    split_test.cc
+    split_v_test.cc
+    strided_slice_test.cc
+    sub_test.cc
+    svdf_test.cc
+    tanh_test.cc
+    transpose_conv_test.cc
+    unpack_test.cc
+    zeros_like_test.cc)

--- a/tensorflow/lite/micro/kernels/cmsis_nn/CMakeLists.txt
+++ b/tensorflow/lite/micro/kernels/cmsis_nn/CMakeLists.txt
@@ -1,0 +1,122 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option(TENSORFLOW_CMSIS_NN "Enable Arm CMSIS-NN" OFF)
+
+if (NOT TENSORFLOW_CMSIS_NN)
+    return()
+endif()
+
+# Build CMSIS-NN operators
+target_compile_definitions(tensorflow-microlite PUBLIC CMSIS_NN)
+
+target_include_directories(tensorflow-microlite PUBLIC
+    ${TENSORFLOW_CMSIS_PATH}
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/DSP/Include
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/Core/Include
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Include)
+
+target_sources(tensorflow-microlite PRIVATE
+    add.cc
+    conv.cc
+    depthwise_conv.cc
+    fully_connected.cc
+    mul.cc
+    pooling.cc
+    softmax.cc
+    svdf.cc)
+
+# Build CMSIS-NN
+# TODO Building CMSIS-NN should be part of CMSIS
+add_library(cmsis-nn STATIC)
+
+target_include_directories(cmsis-nn PRIVATE
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/DSP/Include
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/Core/Include
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Include)
+
+target_sources(cmsis-nn PRIVATE
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_mul_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/BasicMathFunctions/arm_elementwise_add_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7_opt.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15_opt.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q15.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_q7.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/FullyConnectedFunctions/arm_fully_connected_mat_q7_vec_q15_opt.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/SVDFunctions/arm_svdf_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConcatenationFunctions/arm_concatenation_s8_z.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConcatenationFunctions/arm_concatenation_s8_x.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConcatenationFunctions/arm_concatenation_s8_w.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConcatenationFunctions/arm_concatenation_s8_y.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_depthwise_conv_s8_core.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_u8_basic_ver1.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_s8_fast.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_q7_q15_reordered.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_q7_q15.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_RGB.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1x1_HWC_q7_fast_nonsquare.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7_nonsquare.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast_nonsquare.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8_opt.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_3x3_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_basic.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q15_fast.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_fast_nonsquare.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_nn_mat_mult_kernel_s8_s16_reordered.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_separable_conv_HWC_q7.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_1_x_n_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_HWC_q7_basic_nonsquare.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_convolve_wrapper_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ConvolutionFunctions/arm_depthwise_conv_wrapper_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/PoolingFunctions/arm_pool_q7_HWC.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/PoolingFunctions/arm_avgpool_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/PoolingFunctions/arm_max_pool_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ActivationFunctions/arm_relu_q15.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ActivationFunctions/arm_relu_q7.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ActivationFunctions/arm_nn_activations_q7.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ActivationFunctions/arm_relu6_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ActivationFunctions/arm_nn_activations_q15.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_add_q7.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_depthwise_conv_nt_t_padded_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_no_shift.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_depthwise_conv_nt_t_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nntables.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_accumulate_q7_to_q15.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mult_q7.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mult_q15.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_reordered_with_offset.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_with_offset.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_4x_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mult_nt_t_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_vec_mat_mult_t_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_nn_mat_mul_core_1x_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/NNSupportFunctions/arm_q7_to_q15_no_shift.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_q15.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_u8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_q7.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/SoftmaxFunctions/arm_softmax_with_batch_q7.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/SVDFunctions/arm_svdf_s8.c
+    ${TENSORFLOW_CMSIS_PATH}/CMSIS/NN/Source/ReshapeFunctions/arm_reshape_s8.c)
+
+target_link_libraries(tensorflow-microlite PUBLIC cmsis-nn)

--- a/tensorflow/lite/micro/kernels/ethos_u/CMakeLists.txt
+++ b/tensorflow/lite/micro/kernels/ethos_u/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option(TENSORFLOW_ETHOS_U "Enable Arm Ethos-U NPU" OFF)
+
+if (NOT TENSORFLOW_ETHOS_U)
+    return()
+endif()
+
+# Build glue layer
+target_sources(tensorflow-microlite PRIVATE ethosu.cc)
+target_compile_definitions(tensorflow-microlite PUBLIC ETHOSU)
+
+# Build Ethos-U driver
+set(CMSIS_PATH "${TENSORFLOW_CMSIS_PATH}" CACHE PATH "Path to CMSIS.")
+add_subdirectory(${TENSORFLOW_ETHOS_U_PATH} ethos-u)
+target_link_libraries(tensorflow-microlite PUBLIC ethosu_core_driver)

--- a/tensorflow/lite/micro/memory_planner/CMakeLists.txt
+++ b/tensorflow/lite/micro/memory_planner/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(NAMES emerg alert crit err warning notice info debug)
+set(TENSORFLOW_MEMORY_PLANNER "greedy" CACHE STRING "Driver log severity level ${NAMES}")
+set_property(CACHE TENSORFLOW_MEMORY_PLANNER PROPERTY STRINGS ${NAMES})
+
+if (${TENSORFLOW_MEMORY_PLANNER} STREQUAL "greedy")
+    target_sources(tensorflow-microlite PRIVATE
+        greedy_memory_planner.cc)
+    tensorflow_add_tests(
+        greedy_memory_planner_test.cc)
+else()
+    target_sources(tensorflow-microlite PRIVATE
+        linear_memory_planner.cc)
+    tensorflow_add_tests(
+        linear_memory_planner_test.cc)
+endif()

--- a/tensorflow/lite/micro/targets/sparkfun_edge/CMakeLists.txt
+++ b/tensorflow/lite/micro/targets/sparkfun_edge/CMakeLists.txt
@@ -1,0 +1,146 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(../../cmake/helpers.cmake)
+
+#############################################################################
+# Toolchain setup
+#############################################################################
+
+if (NOT CMAKE_TOOLCHAIN_FILE)
+    download_third_party(tensorflow-gcc-embedded
+                         URL "http://mirror.tensorflow.org/developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2"
+                         URL_MD5 299ebd3f1c2c90930d28ab82e5d8d6c0)
+
+    set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/cmake/toolchain/arm-none-eabi-gcc.cmake)
+endif()
+
+#############################################################################
+# Project
+#############################################################################
+
+cmake_minimum_required(VERSION 3.15.6)
+
+project(tensorflow-sparkfun-edge VERSION 0.0.1)
+
+include(CTest)
+
+#############################################################################
+# Tensorflow
+#############################################################################
+
+# Define target
+set(TENSORFLOW_TARGET "sparkfun_edge")
+
+# Override default Tensorflow microlite settings
+option(TENSORFLOW_CMSIS_NN "Enable Arm CMSIS-NN" ON)
+
+# Build Tensorflow microlite
+add_subdirectory(../.. tensorflow-microlite)
+
+#############################################################################
+# Download thirdparty
+#############################################################################
+
+# AM SDK
+download_third_party(tensorflow-am-sdk
+                     URL "http://mirror.tensorflow.org/s3.asia.ambiqmicro.com/downloads/AmbiqSuite-Rel2.2.0.zip"
+                     URL_MD5 7605fa2d4d97e6bb7a1190c92b66b597
+                     PATCHES startup_gcc.c.patch hello_world.ld.patch)
+
+# SF BSPS
+download_third_party(tensorflow-sf-bsps
+                     URL "http://mirror.tensorflow.org/github.com/sparkfun/SparkFun_Apollo3_AmbiqSuite_BSPs/archive/v0.0.7.zip"
+                     URL_MD5 34199f7e754735661d1c8a70a40ca7a3)
+
+FetchContent_GetProperties(tensorflow-cmsis)
+
+#############################################################################
+# Tensorflow sparkfun
+#############################################################################
+
+set(BOARD_BSP_PATH ${tensorflow-am-sdk_SOURCE_DIR}/boards/apollo3_evb/bsp)
+
+add_library(tensorflow-sparkfun-edge STATIC)
+
+target_include_directories(tensorflow-sparkfun-edge PUBLIC
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/Core/Include
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Include
+    ${tensorflow-sf-bsps_SOURCE_DIR}/edge/bsp
+    ${tensorflow-sf-bsps_SOURCE_DIR}/common/third_party/hm01b0
+#    ${tensorflow-am-sdk_SOURCE_DIR}/boards/apollo3_evb/bsp
+    ${tensorflow-am-sdk_SOURCE_DIR}/mcu/apollo3
+    ${tensorflow-am-sdk_SOURCE_DIR}/mcu/apollo3/regs
+    ${tensorflow-am-sdk_SOURCE_DIR}/mcu/apollo3/hal
+    ${tensorflow-am-sdk_SOURCE_DIR}/CMSIS/AmbiqMicro/Include
+    ${tensorflow-am-sdk_SOURCE_DIR}/devices
+    ${tensorflow-am-sdk_SOURCE_DIR}/utils)
+
+target_sources(tensorflow-sparkfun-edge PRIVATE
+    ${tensorflow-am-sdk_SOURCE_DIR}/boards/apollo3_evb/examples/hello_world/gcc/startup_gcc.c
+    ${tensorflow-am-sdk_SOURCE_DIR}/utils/am_util_delay.c
+    ${tensorflow-am-sdk_SOURCE_DIR}/utils/am_util_faultisr.c
+    ${tensorflow-am-sdk_SOURCE_DIR}/utils/am_util_id.c
+    ${tensorflow-am-sdk_SOURCE_DIR}/utils/am_util_stdio.c
+    ${tensorflow-am-sdk_SOURCE_DIR}/devices/am_devices_led.c)
+
+target_sources(tensorflow-sparkfun-edge PRIVATE
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/BasicMathFunctions/arm_dot_prod_q15.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/BasicMathFunctions/arm_mult_q15.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/TransformFunctions/arm_rfft_init_q15.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/TransformFunctions/arm_rfft_q15.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/TransformFunctions/arm_bitreversal2.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/TransformFunctions/arm_cfft_q15.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/TransformFunctions/arm_cfft_radix4_q15.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/CommonTables/arm_const_structs.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/CommonTables/arm_common_tables.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/StatisticsFunctions/arm_mean_q15.c
+    ${tensorflow-cmsis_SOURCE_DIR}/CMSIS/DSP/Source/StatisticsFunctions/arm_max_q7.c)
+
+target_link_libraries(tensorflow-sparkfun-edge PUBLIC
+    ${BOARD_BSP_PATH}/gcc/bin/libam_bsp.a
+    ${tensorflow-am-sdk_SOURCE_DIR}/mcu/apollo3/hal/gcc/bin/libam_hal.a
+    m stdc++ c nosys gcc)
+
+if (EXISTS "${tensorflow-gcc-embedded_SOURCE_DIR}/lib/gcc/arm-none-eabi/7.3.1/thumb/v7e-m/fpv4-sp/hard/crtbegin.o")
+    target_link_libraries(tensorflow-sparkfun-edge PUBLIC
+        "${tensorflow-gcc-embedded_SOURCE_DIR}/lib/gcc/arm-none-eabi/7.3.1/thumb/v7e-m/fpv4-sp/hard/crtbegin.o")
+endif()
+
+target_link_options(tensorflow-sparkfun-edge PUBLIC
+    -nostdlib
+    --entry Reset_Handler
+    -T${tensorflow-am-sdk_SOURCE_DIR}/boards/apollo3_evb/examples/hello_world/gcc/hello_world.ld)
+
+#############################################################################
+# Tensorflow tests
+#############################################################################
+
+target_link_libraries(tensorflow-tests INTERFACE
+    tensorflow-sparkfun-edge)
+
+#############################################################################
+# Tensorflow microlite
+#############################################################################
+
+target_compile_definitions(tensorflow-microlite PUBLIC
+    __FPU_PRESENT=1 # Remove
+    NDEBUG          # Remove
+    PART_apollo3
+    AM_PACKAGE_BGA
+    AM_PART_APOLLO3
+    ARM_MATH_CM4
+    GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK
+    TF_LITE_MCU_DEBUG_LOG)

--- a/tensorflow/lite/micro/targets/sparkfun_edge/cmake/toolchain/arm-none-eabi-gcc.cmake
+++ b/tensorflow/lite/micro/targets/sparkfun_edge/cmake/toolchain/arm-none-eabi-gcc.cmake
@@ -1,0 +1,87 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(FetchContent)
+
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m4")
+set(CMAKE_C_COMPILER "${tensorflow-gcc-embedded_SOURCE_DIR}/bin/arm-none-eabi-gcc")
+set(CMAKE_CXX_COMPILER "${tensorflow-gcc-embedded_SOURCE_DIR}/bin/arm-none-eabi-g++")
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
+
+# CPU target
+add_compile_options(
+    -mcpu=${CMAKE_SYSTEM_PROCESSOR}
+    -mthumb
+    -mfpu=fpv4-sp-d16
+    -mfloat-abi=hard
+
+    -ggdb
+    -nostdlib
+
+    -fno-unwind-tables
+    -ffunction-sections
+    -fdata-sections
+    -fmessage-length=0
+    -fno-delete-null-pointer-checks
+    -fomit-frame-pointer
+    -funsigned-char
+    "$<$<COMPILE_LANGUAGE:CXX>:-fno-rtti;-fno-exceptions;-fno-threadsafe-statics;-fno-use-cxa-atexit>"
+)
+
+add_link_options(
+    -mcpu=${CMAKE_SYSTEM_PROCESSOR}
+    -mthumb
+    -mfpu=fpv4-sp-d16
+    -mfloat-abi=hard
+
+    -nostartfiles
+    -static
+    -nostdlib
+    --specs=nano.specs
+)
+
+# Complation warnings
+add_compile_options(
+    -Wall
+    -Wextra
+#    -Werror
+    -Wsign-compare
+    -Wdouble-promotion
+    -Wmissing-field-initializers  # Remove
+    -Wshadow
+    -Wswitch
+    -Wvla
+    -Wstrict-aliasing
+    -Wunused-variable
+    -Wunused-function
+    -Wno-missing-field-initializers
+    -Wno-strict-aliasing
+    -Wno-type-limits
+    -Wno-unused-function
+    -Wno-unused-parameter)
+
+# Remove
+add_compile_options(
+    -O3
+    -MMD)

--- a/tensorflow/lite/micro/targets/sparkfun_edge/hello_world.ld.patch
+++ b/tensorflow/lite/micro/targets/sparkfun_edge/hello_world.ld.patch
@@ -1,0 +1,52 @@
+diff --git a/boards/apollo3_evb/examples/hello_world/gcc/hello_world.ld b/boards/apollo3_evb/examples/hello_world/gcc/hello_world.ld
+--- a/boards/apollo3_evb/examples/hello_world/gcc/hello_world.ld
++++ b/boards/apollo3_evb/examples/hello_world/gcc/hello_world.ld
+@@ -1,6 +1,6 @@
+ /******************************************************************************
+  *
+- * hello_world.ld - Linker script for applications using startup_gnu.c
++ * apollo3evb.ld - Linker script for applications using startup_gcc.c
+  *
+  *****************************************************************************/
+ ENTRY(Reset_Handler)
+@@ -20,12 +20,29 @@
+         KEEP(*(.patch))
+         *(.text)
+         *(.text*)
++
++	/* These are the C++ global constructors.  Stick them all here and
++	 * then walk through the array in main() calling them all.
++	 */
++	_init_array_start = .;
++	KEEP (*(SORT(.init_array*)))
++	_init_array_end = .;
++
++	/* XXX Currently not doing anything for global destructors. */
++
+         *(.rodata)
+         *(.rodata*)
+         . = ALIGN(4);
+         _etext = .;
+     } > FLASH
+ 
++    __exidx_start = .;
++    .ARM.exidx :
++    {
++        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
++    } > FLASH
++    __exidx_end = .;
++    
+     /* User stack section initialized by startup code. */
+     .stack (NOLOAD):
+     {
+@@ -58,6 +75,10 @@
+         . = ALIGN(4);
+         _ebss = .;
+     } > SRAM
++    /* Add this to satisfy reference to symbol "end" from libnosys.a(sbrk.o)
++     * to denote the HEAP start.
++     */
++   end = .;
+ 
+     .ARM.attributes 0 : { *(.ARM.attributes) }
+ }

--- a/tensorflow/lite/micro/targets/sparkfun_edge/startup_gcc.c.patch
+++ b/tensorflow/lite/micro/targets/sparkfun_edge/startup_gcc.c.patch
@@ -1,0 +1,12 @@
+diff --git a/boards/apollo3_evb/examples/hello_world/gcc/startup_gcc.c b/boards/apollo3_evb/examples/hello_world/gcc/startup_gcc.c
+--- a/boards/apollo3_evb/examples/hello_world/gcc/startup_gcc.c
++++ b/boards/apollo3_evb/examples/hello_world/gcc/startup_gcc.c
+@@ -111,7 +111,7 @@
+ //
+ //*****************************************************************************
+ __attribute__ ((section(".stack")))
+-static uint32_t g_pui32Stack[1024];
++static uint32_t g_pui32Stack[1024*20];
+ 
+ //*****************************************************************************
+ //

--- a/tensorflow/lite/micro/testing/CMakeLists.txt
+++ b/tensorflow/lite/micro/testing/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+target_sources(tensorflow-microlite PRIVATE
+    test_conv_model.cc)


### PR DESCRIPTION
This patch adds a CMake based build system for Tensorflow Lite for
Microcontrollers. The build system is provided for demonostration
purpose, to show what a CMake based build system could look
like.

This patch includes:
  - Building the microlite library.
  - Building unit tests and how to run them with CTest.
  - How to download 3rd parties.
  - Cross compiling with GCC and Arm Clang.

CMake brings many benefits, but perhaps the most importent advantage
is that CMake allows TFLu to be included by a parent CMake project
and cross compiled using a common toolchain file.

CMake runs on several host platforms, including Linux, Windows
and MacOS.

Change-Id: I5a632a7bcb8fc354c70b474dc0d2f6b25a3c0ab6

Add Sparkfun edge target

Adding target that demonstrates how the Tensorflow CMake project
can be included from a parent project.

This target shows how to preset default parameters and how to provide
a custom toolchain file tailored for this target.

Change-Id: I24d42b2b73f54ef82553631f06c7ae9fe7536088